### PR TITLE
Allow a closed version range of v4 → v8

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "MagicExtensions",
     platforms: [
-        .iOS(.v10),
+        .iOS(.v13),
         .macOS(.v10_12)
     ],
     products: [

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
             targets: ["MagicExt-OIDC"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/magiclabs/magic-ios.git", from:"4.0.0"),
+        .package(url: "https://github.com/magiclabs/magic-ios.git", from:"7.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "MagicExtensions",
     platforms: [
-        .iOS(.v15),
+        .iOS(.v10),
         .macOS(.v10_12)
     ],
     products: [
@@ -19,7 +19,7 @@ let package = Package(
             targets: ["MagicExt-OIDC"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/magiclabs/magic-ios.git", from:"7.0.0"),
+        .package(url: "https://github.com/magiclabs/magic-ios.git", "4.0.0"..<"8.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "MagicExtensions",
     platforms: [
-        .iOS(.v10),
+        .iOS(.v15),
         .macOS(.v10_12)
     ],
     products: [


### PR DESCRIPTION
Currently, the extensions are only compatible with v4.0.0 → <v5.0.0 as specified in the Package.swift ([docs on from:](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#:~:text=A%20package%20dependency%20consists%20of,other%20Swift%20package%20can%20use.))

This allows it to be safely included when using v7 of the Magic SDK.

**Note**: I don't know what future compatibility looks like, so if you want v8 to work with the extensions when you ship it, you'll need to update the range to include v8. Making the range open would be me making a compatibility promise to your users that I have no idea if you intend to keep.