### PR TITLE
Updates package.Swift with Latest magic-ios version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
             targets: ["MagicExt-OIDC"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/magiclabs/magic-ios.git", from:"4.0.0"),
+        .package(url: "https://github.com/magiclabs/magic-ios.git", from: "7.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
As pointed out by the community in PR https://github.com/magiclabs/magic-ios-ext/pull/5 we should to update the expected compatible version of `magic-ios` with the latest version of this extension package.  