### PR TITLE
Bump iOS min version in `swift.package` to v13

### DIFF
--- a/MagicExt-OAuth.podspec
+++ b/MagicExt-OAuth.podspec
@@ -4,7 +4,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'MagicExt-OAuth'
-  s.version          = '1.1.2'
+  s.version          = '1.1.3'
   s.summary          = 'Magic IOS Extension - OAuth'
 
   s.description      = <<-DESC
@@ -16,7 +16,7 @@ TODO: Add long description of the pod here.
   s.author           = { 'Jerry Liu' => 'jerry@magic.link' }
   s.source           = { :git => 'https://github.com/magicLabs/magic-ios-ext.git', :tag => s.version.to_s }
   s.swift_version = '5.0'
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '13.0'
 #   s.osx.deployment_target  = '10.12'
 
   s.source_files = 'Sources/MagicExt-OAuth/**/*'

--- a/MagicExt-OAuth.podspec
+++ b/MagicExt-OAuth.podspec
@@ -17,7 +17,7 @@ TODO: Add long description of the pod here.
   s.source           = { :git => 'https://github.com/magicLabs/magic-ios-ext.git', :tag => s.version.to_s }
   s.swift_version = '5.0'
   s.ios.deployment_target = '13.0'
-#   s.osx.deployment_target  = '10.12'
+#   s.osx.deployment_target  = '10.15'
 
   s.source_files = 'Sources/MagicExt-OAuth/**/*'
 

--- a/MagicExt-OAuth.podspec
+++ b/MagicExt-OAuth.podspec
@@ -4,7 +4,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'MagicExt-OAuth'
-  s.version          = '1.1.3'
+  s.version          = '2.0.0'
   s.summary          = 'Magic IOS Extension - OAuth'
 
   s.description      = <<-DESC

--- a/MagicExt-OIDC.podspec
+++ b/MagicExt-OIDC.podspec
@@ -17,7 +17,7 @@ TODO: Add long description of the pod here.
   s.source           = { :git => 'https://github.com/magicLabs/magic-ios-ext.git', :tag => s.version.to_s }
   s.swift_version = '5.0'
   s.ios.deployment_target = '13.0'
-#   s.osx.deployment_target  = '10.12'
+#   s.osx.deployment_target  = '10.15'
 
   s.source_files = 'Sources/MagicExt-OIDC/**/*'
 

--- a/MagicExt-OIDC.podspec
+++ b/MagicExt-OIDC.podspec
@@ -4,7 +4,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'MagicExt-OIDC'
-  s.version          = '1.1.2'
+  s.version          = '1.1.3'
   s.summary          = 'Magic IOS Extension - OIDC'
 
   s.description      = <<-DESC
@@ -16,7 +16,7 @@ TODO: Add long description of the pod here.
   s.author           = { 'Jerry Liu' => 'jerry@magic.link' }
   s.source           = { :git => 'https://github.com/magicLabs/magic-ios-ext.git', :tag => s.version.to_s }
   s.swift_version = '5.0'
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '13.0'
 #   s.osx.deployment_target  = '10.12'
 
   s.source_files = 'Sources/MagicExt-OIDC/**/*'

--- a/MagicExt-OIDC.podspec
+++ b/MagicExt-OIDC.podspec
@@ -4,7 +4,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'MagicExt-OIDC'
-  s.version          = '1.1.3'
+  s.version          = '2.0.0'
   s.summary          = 'Magic IOS Extension - OIDC'
 
   s.description      = <<-DESC

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "MagicExtensions",
     platforms: [
-        .iOS(.v10),
+        .iOS(.v13),
         .macOS(.v10_12)
     ],
     products: [

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "MagicExtensions",
     platforms: [
         .iOS(.v13),
-        .macOS(.v10_12)
+        .macOS(.v10_15)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.


### PR DESCRIPTION
Drops support for iOS versions 10, 11, 12 and close security vulnerabilities to zero-day exploits like [pegasus](https://en.wikipedia.org/wiki/Pegasus_(spyware)) 

Fixes Issue https://github.com/magiclabs/magic-ios-ext/issues/8